### PR TITLE
Use /usr/bin/env for portability

### DIFF
--- a/christmas
+++ b/christmas
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NOW=$(date -d 'now' +%s)
 CHRISTMAS=$(date -d 'Dec 25' +%s)
@@ -11,7 +11,7 @@ MINUTES=0
 # https://stackoverflow.com/a/12199816
 if ((DIFF > 59)); then
 	((DIFF=DIFF/60))
-	
+
 	if ((DIFF > 59)); then
 		((MINUTES=DIFF%60))
 		((DIFF=DIFF/60))


### PR DESCRIPTION
Some distros (NixOS) don't have bash in `/bin/`. But pretty much all distros have env in `/usr/bin/`

This makes the script run on NixOS.